### PR TITLE
Use forCountTabs in reload and hardReload.

### DIFF
--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -320,38 +320,20 @@ const BackgroundCommands = {
     }
   },
 
-  reload({ count, tabId, registryEntry, tab: { windowId } }) {
+  reload({ count, tab, registryEntry }) {
     const bypassCache = registryEntry.options.hard != null ? registryEntry.options.hard : false;
-    return chrome.tabs.query({ windowId }, function (tabs) {
-      const position = (function () {
-        for (let index = 0; index < tabs.length; index++) {
-          const tab = tabs[index];
-          if (tab.id === tabId) return index;
-        }
-      })();
-      tabs = [...tabs.slice(position), ...tabs.slice(0, position)];
-      count = Math.min(count, tabs.length);
-      for (const tab of tabs.slice(0, count)) {
-        chrome.tabs.reload(tab.id, { bypassCache });
-      }
+    return forCountTabs(count, tab, (tab) => {
+      chrome.tabs.reload(tab.id, { bypassCache });
     });
   },
 
-  hardReload({ count, tabId, tab: { windowId } }) {
+  hardReload({ count, tab }) {
     // For hard reload set bypassCache to true
     const bypassCache = true;
-    return chrome.tabs.query({ windowId }, function (tabs) {
-        let startIndex = tabs.findIndex(tab => tab.id === tabId);
-        if (startIndex === -1) return; // Exit if tabId is not found
-
-        let processed = 0;
-        while (processed < count) {
-            chrome.tabs.reload(tabs[startIndex].id, { bypassCache });
-            processed++;
-            startIndex = (startIndex + 1) % tabs.length; // Wrap around if needed
-        }
+    return forCountTabs(count, tab, (tab) => {
+      chrome.tabs.reload(tab.id, { bypassCache });
     });
-  }
+  },
 };
 
 const forCountTabs = (count, currentTab, callback) =>


### PR DESCRIPTION
## Description

Simplify the reload and hardReload functions to use forCountTabs so that their implementation is trivial. This also gives the benefit that all the functionality of the addon will remain consistent (we handle counts the same way for all functions), and that we will easily get any future fixes (such as handling hidden tabs) to the count logic.